### PR TITLE
Fix Angular component metadata

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { RouterOutlet } from '@angular/router';
   standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
 }

--- a/src/app/cards/components/card-list/card-list.component.ts
+++ b/src/app/cards/components/card-list/card-list.component.ts
@@ -16,7 +16,7 @@ import { MovieCardComponent } from '../card/movie-card.component';
   standalone: true,
   imports: [CommonModule, MovieCardComponent],
   templateUrl: './card-list.component.html',
-  styleUrl: './card-list.component.scss'
+  styleUrls: ['./card-list.component.scss']
 })
 export class CardListComponent implements OnInit, OnChanges {
   @Input() public movies: MovieI[] = [];

--- a/src/app/shared/components/header-button/header-button.component.ts
+++ b/src/app/shared/components/header-button/header-button.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   standalone: true,
   imports: [],
   templateUrl: './header-button.component.html',
-  styleUrl: './header-button.component.scss'
+  styleUrls: ['./header-button.component.scss']
 })
 export class HeaderButtonComponent {
 

--- a/src/app/shared/components/header-user/header-user.component.ts
+++ b/src/app/shared/components/header-user/header-user.component.ts
@@ -7,7 +7,7 @@ import { SearchBoxComponent } from '@shared/components/search-box/search-box.com
   standalone: true,
   imports: [RouterModule,SearchBoxComponent],
   templateUrl: './header-user.component.html',
-  styleUrl: './header-user.component.scss'
+  styleUrls: ['./header-user.component.scss']
 })
 export class HeaderUserComponent {
 

--- a/src/app/shared/components/search-box/search-box.component.ts
+++ b/src/app/shared/components/search-box/search-box.component.ts
@@ -9,7 +9,7 @@ import { AuthService } from 'src/app/services/auth.service'; // si vas a cerrar 
   standalone: true,
   imports: [CommonModule],
   templateUrl: './card-search-box.component.html',
-  styleUrl: './card-search-box.component.scss'
+  styleUrls: ['./card-search-box.component.scss']
 })
 export class SearchBoxComponent {
   menuVisible = false;


### PR DESCRIPTION
## Summary
- fix property name `styleUrls` across components

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a098f6c83228fdbd917ffc29763