### PR TITLE
Add Dockerfile for .NET backend

### DIFF
--- a/ApiChidasPelis/Dockerfile
+++ b/ApiChidasPelis/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY ["ApiChidasPelis/ApiChidasPelis.csproj", "ApiChidasPelis/"]
+RUN dotnet restore "ApiChidasPelis/ApiChidasPelis.csproj"
+COPY ApiChidasPelis/ ApiChidasPelis/
+WORKDIR /src/ApiChidasPelis
+RUN dotnet publish "ApiChidasPelis.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:5000
+EXPOSE 5000
+ENTRYPOINT ["dotnet", "ApiChidasPelis.dll"]


### PR DESCRIPTION
## Summary
- dockerize the ApiChidasPelis .NET backend

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547b5eb8f483228dfd4dcd17b8ddbb